### PR TITLE
Use Snowsql-1.2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN bash snowsql-${VERSION}-linux_x86_64.bash
 # Switch to the non-root user
 USER snowflake
 
-# Run the SnowSQL client once, allowing it to auto-upgrade to the latest version.
+# Run the SnowSQL client once, allowing it to auto-upgrade to the latest minor version (1.1.x).
 # See https://docs.snowflake.com/en/user-guide/snowsql-install-config.html#label-understanding-auto-upgrades
 RUN snowsql -v
 

--- a/Dockerfile-snowsql-1.2
+++ b/Dockerfile-snowsql-1.2
@@ -1,0 +1,42 @@
+FROM ubuntu:18.04
+
+LABEL maintainer Sky Butter <skybutter@gmail.com>
+
+# snowsql 1.2.x install bash require zip/unzip to run
+RUN apt-get update && apt-get --assume-yes install  curl \
+    zip unzip
+
+# Create non-root user
+RUN groupadd --system snowflake --gid 444 && \
+useradd --uid 444 --system --gid snowflake --home-dir /home/snowflake --create-home --shell /sbin/nologin --comment "Docker image user" snowflake && \
+chown -R snowflake:snowflake /home/snowflake
+
+# default to being in the user's home directory
+WORKDIR /home/snowflake
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+#ENV VERSION 1.1.86
+ENV VERSION 1.2.10
+ENV SNOWSQL_DEST /usr/local/bin
+ENV SNOWSQL_LOGIN_SHELL /home/snowflake/.bashrc
+
+# grab the installation script.  The url is different from version 1.1.x.
+RUN curl -o snowsql-${VERSION}-linux_x86_64.bash https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.10-linux_x86_64.bash
+
+# Install the tool
+RUN bash snowsql-${VERSION}-linux_x86_64.bash
+
+# Switch to the non-root user
+USER snowflake
+
+# Default snowsql config bootstrap log file location is set to wrong location.  Caused an error.
+COPY --chown=snowflake config-1.2.10 /home/snowflake/.snowsql/config
+
+# Run the SnowSQL client once, allowing it to auto-upgrade to the latest version.
+# See https://docs.snowflake.com/en/user-guide/snowsql-install-config.html#label-understanding-auto-upgrades
+RUN snowsql -v
+
+ENTRYPOINT ["snowsql"]
+
+CMD ["-v"]

--- a/config-1.2.10
+++ b/config-1.2.10
@@ -1,0 +1,76 @@
+[connections]          
+# *WARNING* *WARNING* *WARNING* *WARNING* *WARNING* *WARNING*
+# 
+# The Snowflake user password is stored in plain text in this file.
+# Pay special attention to the management of this file.
+# Thank you.
+# 
+# *WARNING* *WARNING* *WARNING* *WARNING* *WARNING* *WARNING*
+
+#If a connection doesn't specify a value, it will default to these
+#
+#accountname = defaultaccount
+#region = defaultregion
+#username = defaultuser
+#password = defaultpassword
+#dbname = defaultdb
+#schemaname = defaultschema
+#warehousename = defaultwarehouse
+#rolename = defaultrolename
+#proxy_host = defaultproxyhost
+#proxy_port = defaultproxyport
+
+[connections.example]
+#Can be used in SnowSql as #connect example
+
+accountname = accountname
+username = username
+password = password1234
+
+[variables]
+#Loads these variables on startup
+#Can be used in SnowSql as select $example_variable
+
+example_variable=27
+
+[options]
+# If set to false auto-completion will not occur interactive mode.
+auto_completion = True
+
+# main log file location. The file includes the log from SnowSQL main
+# executable.
+log_file = ~/.snowsql/log
+
+# bootstrap log file location. The file includes the log from SnowSQL bootstrap
+# executable.
+log_bootstrap_file = ~/.snowsql/log_bootstrap
+
+# Default log level. Possible values: "CRITICAL", "ERROR", "WARNING", "INFO"
+# and "DEBUG".
+log_level = WARNING
+
+# Timing of sql statments and table rendering.
+timing = True
+
+# Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
+# orgtbl, rst, mediawiki, html, latex, latex_booktabs, tsv.
+# Recommended: psql, fancy_grid and grid.
+output_format = psql
+
+# Keybindings: Possible values: emacs, vi.
+# Emacs mode: Ctrl-A is home, Ctrl-E is end. All emacs keybindings are available in the REPL.
+# When Vi mode is enabled you can use modal editing features offered by Vi in the REPL.
+key_bindings = emacs
+
+# OCSP Fail Open Mode.
+# The only OCSP scenario which will lead to connection failure would be OCSP response with a
+# revoked status. Any other errors or in the OCSP module will not raise an error.
+# ocsp_fail_open = True
+
+# Enable temporary credential file for Linux users
+# For Linux users, since there are no OS-key-store, an unsecure temporary credential for SSO can be enabled by this option. The default value for this option is False.
+# client_store_temporary_credential = True
+
+# Repository Base URL
+# The endpoint to download the SnowSQL main module.
+repository_base_url = https://sfc-repo.snowflakecomputing.com/snowsql


### PR DESCRIPTION
Add another Dockerfile to use the snowsql-1.2.x version.  
Snowsql-1.2.x use a different URL.  The 1.2.x bash install script need zip/unzip package.
Using the config file came from snowsql-1.2.x has a warning when running snowsql.  Thus added the config file with modified file path of log and log_bootstrap to remove the warning.